### PR TITLE
Fixing post-init additions to the tree functionlity using lists by means of casting lists to polariList type

### DIFF
--- a/dataChannels.py
+++ b/dataChannels.py
@@ -23,7 +23,7 @@ import os, json, logging, datetime
 class dataChannel(managedFile, treeObject):
     @treeObjectInit
     def __init__(self, manager, name=None, Path=None):
-        managedFile.__init__(self, name=name, extension='json')
+        managedFile.__init__(self, name=name, extension='json', manager=manager)
         #The JSON currently being manipulated in the python object
         self.jsonDict = []
         #The recorded JSON from the last time the JSON File was read.

--- a/managedDB.py
+++ b/managedDB.py
@@ -27,7 +27,7 @@ import os, json, sqlite3, sys
 DBtypesList = ['Polari', 'App', 'Test']
 DBstatuses = ['UnInitialized Tables', 'Finalized DB']
 
-class managedDatabase(treeObject, managedFile):
+class managedDatabase(managedFile):
     #Creates an anonymous Database, used only when looking to load a pre-existing Database
     @treeObjectInit
     def __init__(self, name=None, manager=None, DBurl=None, DBtype=None, tables=[], inRAM=False):

--- a/managedExecutables.py
+++ b/managedExecutables.py
@@ -19,8 +19,8 @@ LanguageExtensionsDict = {'py':'python','js':'javascript','html':'hypertextmarku
 
 class managedExecutable(managedFile):
 
-    def __init__(self, name=None, extension=None, Path = None):
-        managedFile.__init__(self, name=name, extension=extension, Path = Path)
+    def __init__(self, name=None, extension=None, Path = None, manager=None):
+        managedFile.__init__(self, name=name, extension=extension, Path = Path, manager=manager)
         #The full name of the software language being used in this file.
         self.language = None
         self.setLanguage()

--- a/managedFiles.py
+++ b/managedFiles.py
@@ -14,7 +14,7 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #from functionalityAnalysis import *
 #CANNOT DEFINE as @treeObj on managedFile level, causes recursive imports!!
-#import objectTreeDecorators
+from objectTreeDecorators import treeObject, treeObjectInit
 import logging, os
 #Centralized global variable arrays accounting for the different types of files/file-extensions the system can handle
 #Each individual array accounts for a different type of Object which should be utilized for handling a particular type
@@ -49,8 +49,8 @@ def fileObject(name=None, Path=None, extension=None):
 
 #Allows for handling particular file types, and saving them to a register.
 #plty is the custom file extension of the Polarity System.
-class managedFile:
-    
+class managedFile(treeObject):
+    @treeObjectInit
     def __init__(self, name=None, Path=None, extension=None):
         self.name = name
         self.extension = extension

--- a/managedImages.py
+++ b/managedImages.py
@@ -22,10 +22,10 @@ from matplotlib import image as MPLimage
 picExtensions = ['svg', 'pil', 'jpg', 'png', 'pdf', 'gif']
 
 class managedImage(managedFile):
-    def __init__(self, name = None, extension = None, xPix = 100, yPix = 100):
-        managedFile.__init__(self, name=name, extension=extension)
+    def __init__(self, name = None, extension = None, xPix = 100, yPix = 100, manager=None):
+        managedFile.__init__(self, name=name, extension=extension, manager=None)
         if(picExtensions.__contains__(extension)):
-            managedFile.__init__(name)
+            #managedFile.__init__(name)
             #The number of pixels along the x-axis for the current image size, or the width.
             self.xPix = xPix
             #The number of pixels along the y-axis for the current image size, or the height.

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -122,15 +122,19 @@ class treeObject:
             super(treeObject, self).__setattr__(name, value)
             return
         if(self.manager != None and self.branch != None):
+            print("Setting non-standard value on treeObject after manager is set and branch is set.")
             selfPolyObj = self.manager.getObjectTyping(self.__class__)
             selfIds = self.manager.getInstanceIdentifiers(value)
-            selfPath = self.manager.getTuplePathInObjTree(instanceTuple=tuple([selfPolyObj.className, selfIds, self]))
+            selfTuple = self.manager.getInstanceTuple(self)
+            selfPath = self.manager.getTuplePathInObjTree(instanceTuple=selfTuple)
             #Handles the case where the current treeObject already exists in the current manager's Tree.
             if(selfPath != None):
+                print("Found appropriate path for treeObject")
                 polyObj = self.manager.getObjectTyping(self.__class__)
                 if value == None or value == []:
                     pass
                 elif(type(value) == list):
+                    print("Going through list on treeObject post-init.")
                     #Adding a list of objects
                     for inst in value:
                         accountedObjectType = False
@@ -203,6 +207,7 @@ class treeObject:
                             #TODO make a function that swaps any branching on the original tuple to be on the new location.
                 #Handles the case where a single variable is being set.
                 else:
+                    print("Going through single variable assignment post-init on treeObject.")
                     accountedObjectType = False
                     accountedVariableType = False
                     if(type(value).__class__.__name__ in polyObj.objectReferencesDict):
@@ -211,8 +216,8 @@ class treeObject:
                         if(polyObj.objectReferencesDict[type(value).__class__.__name__]):
                             accountedVariableType = True
                             print("Accounted for class type ", value, " as sole value in variable ", name)
-                    newpolyObj = self.getObjectTyping(classObj=value.__class__)
-                    managerPolyTyping = self.getObjectTyping(self.manager.__class__)
+                    newpolyObj = self.manager.getObjectTyping(classObj=value.__class__)
+                    managerPolyTyping = self.manager.getObjectTyping(self.manager.__class__)
                     if(not accountedVariableType):
                         managerPolyTyping.addToObjReferenceDict(referencedClassObj=value.__class__, referenceVarName=name)
                     ids = self.manager.getInstanceIdentifiers(value)
@@ -273,6 +278,8 @@ class treeObject:
                             if(self.manager != value.manager):
                                 value.manager = self.manager
                             #TODO make a function that swaps any branching on the original tuple to be on the new location.
+            else:
+                print("selfPath was not found in tree for object ", self)
         super(treeObject, self).__setattr__(name, value)
 
 

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -153,7 +153,7 @@ class treeObject:
                         elif instPath == None:
                             #print("found an instance with no existing branch, now creating branch on manager: ", inst)
                             newBranch = tuple([inst.__class__.__name__, ids, inst])
-                            self.manager.addNewBranch(traversalList=[], branchTuple=newBranch)
+                            self.manager.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
                             #Make sure the new branch has the current manager and self as it's origin branch set on it.
                             if(self != inst.branch):
                                 inst.branch = self
@@ -184,7 +184,7 @@ class treeObject:
                             #add the new Branch
                             #print("found an instance with no existing branch, now creating branch on manager: ", value)
                             newBranch = tuple([value.__class__.__name__, ids, value])
-                            self.manager.addNewBranch(traversalList=[], branchTuple=newBranch)
+                            self.manager.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
                             #Make sure the new branch has the current manager and self as it's origin branch set on it.
                             if(self != value.branch):
                                 value.branch = self
@@ -235,7 +235,7 @@ class treeObject:
                             elif instPath == None:
                                 #print("found an instance with no existing branch, now creating branch on manager: ", inst)
                                 newBranch = tuple([inst.__class__.__name__, ids, inst])
-                                self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                                self.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
                                 #Make sure the new branch has the current manager set on it.
                                 if(self.manager != inst.manager):
                                     inst.manager = self.manager
@@ -260,7 +260,7 @@ class treeObject:
                             #add the new Branch
                             #print("found an instance with no existing branch, now creating branch on manager: ", value)
                             newBranch = tuple([value.__class__.__name__, ids, value])
-                            self.manager.addNewBranch(traversalList=[], branchTuple=newBranch)
+                            self.manager.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
                             #Make sure the new branch has the current manager set on it.
                             if(self.manager != value.manager):
                                 value.manager = self.manager
@@ -297,7 +297,7 @@ class treeObject:
             if(self.branch == potentialManager):
                 hasBranch = True
             for parentObj in (self.branch.__class__).__bases__:
-                print('parent object name for branch, ', self.branch, ' object instance:')
+                print('parent object name for branch, ', self.branch, ' object instance:', parentObj.__name__)
                 if(parentObj.__name__ == 'treeObject'):
                     hasBranch = True
                     break

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -14,11 +14,12 @@
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #from polyTyping import *
 from functools import wraps
+from polariList import polariList
 import types, inspect, base64
 
 standardTypesPython = ['str','int','float','complex','list','tuple','range','dict',
 'set','frozenset','bool','bytes','bytearray','memoryview', 'type', 'NoneType', 'TextIOWrapper']
-ignoredObjectsPython = ['struct_time', 'API']
+ignoredObjectsPython = ['struct_time', 'API', 'polariList']
 ignoredObjectImports = {'falcon':['API'], 'time':['struct_time']}
 dataTypesPython = standardTypesPython + ignoredObjectsPython
 dataTypesJS = ['undefined','Boolean','Number','String','BigInt','Symbol','null','Object','Function']
@@ -70,6 +71,12 @@ class treeObject:
             self.makeUniqueIdentifier()
 
     def __setattr__(self, name, value):
+        if(type(value).__name__ == 'list'):
+            print("converting from list with value ", value, " to a polariList.")
+            #Instead of initializing a polariList, we try to just cast the list to be type polariList.
+            value = polariList(value)
+            value.jumpstart(treeObjInstance=self)
+            print("Set list value to be polariList: ", value)
         #Case where the current branch that self is meant to be placed on has not yet been defined
         #*the branch must be defined BEFORE the manager value is set.
         #After a manager object is assigned, ensure a polyTypedObject exists for the given object self.
@@ -133,7 +140,7 @@ class treeObject:
                 polyObj = self.manager.getObjectTyping(self.__class__)
                 if value == None:
                     pass
-                elif(type(value).__name__ == "list"):
+                elif(type(value).__name__ == "list" or type(value).__name__ == "polariList"):
                     print("Going through list variable assignment for var ", name ," post-init on treeObject using list ", value)
                     #Adding a list of objects
                     for inst in value:
@@ -225,7 +232,7 @@ class treeObject:
                     #print('Setting attribute to a value: ', value)
                     #print('Found object: "', value ,'" being assigned to an undeclared reference variable: ', name, 'On object: ', self)
                     newpolyObj = self.manager.getObjectTyping(value.__class__)
-                    if(type(value) == list):
+                    if(type(value).__name__ == "list" or type(value).__name__ == "polariList"):
                         #Adding a list of objects
                         for inst in value:
                             #print('Adding one object as element in a list variable, ', name ,' to the manager with value: ', inst)
@@ -352,12 +359,12 @@ class treeObject:
                 continue
             someAttr = getattr(self, someAttrKey)
             atrType = type(someAttr).__name__
-            if(atrType in dataTypesPython and atrType != 'list'):
+            if(atrType in dataTypesPython and atrType != 'list' and atrType != 'polariList'):
                 continue
             atrTypeList = []
             #START OF TREE MANAGEMENT FOR TREEOBJECTS IN LISTS
             #If it is a list, get a list of all referenced object types in the list.
-            if(type(someAttr).__name__ == "list"):
+            if(type(someAttr).__name__ == "list" or type(someAttr).__name__ == "polariList"):
                 for someValue in someAttr:
                     #Make sure the type of each treeObject in the list is recorded.
                     if(type(someValue).__name__ in dataTypesPython):

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -282,7 +282,7 @@ class treeObject:
     #is supposed to be branching off of, and potentialManager is the manager that is
     #supposed to be set.
     def managerSet(self, potentialManager):
-        print("Calling managerSet for treeObject: ", self)
+        #print("Calling managerSet for treeObject: ", self)
         #Checks that the object's manager has been set and is a valid manager.
         hasManager = False
         if(potentialManager != None):
@@ -297,7 +297,7 @@ class treeObject:
             if(self.branch == potentialManager):
                 hasBranch = True
             for parentObj in (self.branch.__class__).__bases__:
-                print('parent object name for branch, ', self.branch, ' object instance:', parentObj.__name__)
+                #print('parent object name for branch, ', self.branch, ' object instance:', parentObj.__name__)
                 if(parentObj.__name__ == 'treeObject'):
                     hasBranch = True
                     break
@@ -308,33 +308,33 @@ class treeObject:
         if not hasManager or not hasBranch:
             return False
         selfTreeTuple = potentialManager.getInstanceTuple(self)
-        print("Getting self path in setManager.")
+        #print("Getting self path in setManager.")
         selfTreePath = potentialManager.getTuplePathInObjTree(selfTreeTuple)
         branchTreeTuple = potentialManager.getInstanceTuple(self.branch)
-        print("Getting branch path in setManager.")
+        #print("Getting branch path in setManager.")
         branchTreePath = potentialManager.getTuplePathInObjTree(instanceTuple=branchTreeTuple)
         #Checks that the manager has a valid polyTyping for this treeObject.
         selfPolyTyping = potentialManager.getObjectTyping(classObj=self.__class__)
         branchPolyTyping = potentialManager.getObjectTyping(classObj=self.branch.__class__)
         if(selfPolyTyping == None or branchPolyTyping == None):
-            print("Could not properly retrieve or set polyTyping on the manager ", potentialManager, " for objects of type ", self.__class__.__name__)
+            #print("Could not properly retrieve or set polyTyping on the manager ", potentialManager, " for objects of type ", self.__class__.__name__)
             return False
         #Handles the case where self has not yet been allocated onto the tree anywhere.
         if(branchTreePath == None):
-            print("The object's branch instance ", self.branch, " has not yet been added to the tree.")
+            #print("The object's branch instance ", self.branch, " has not yet been added to the tree.")
             return False
         elif(selfTreePath == None):
-            print("Adding new branch in managerSet using path: ", branchTreePath, " and tuple: ", selfTreeTuple)
+            #print("Adding new branch in managerSet using path: ", branchTreePath, " and tuple: ", selfTreeTuple)
             potentialManager.addNewBranch(traversalList=branchTreePath, branchTuple=selfTreeTuple)
             selfTreePath = potentialManager.getTuplePathInObjTree(selfTreeTuple)
-            print("Placed new branch into tree using traversalList '", branchTreePath, "' and selfTreeTuple '", selfTreeTuple)
-            print("The new branch's path is: ", selfTreePath)
+            #print("Placed new branch into tree using traversalList '", branchTreePath, "' and selfTreeTuple '", selfTreeTuple)
+            #print("The new branch's path is: ", selfTreePath)
             if(selfTreePath == None):
-                print("ERROR: Attempted to place self into tree for instance ", self, " by branching from instance ", self.branch, " but failed.")
+                #print("ERROR: Attempted to place self into tree for instance ", self, " by branching from instance ", self.branch, " but failed.")
                 return
         #Retrieves the Branching off of the current object
         selfTreePath = potentialManager.getTuplePathInObjTree(selfTreeTuple)
-        print("selfTreePath in setManager after placing self on Tree: ", selfTreePath)
+        #print("selfTreePath in setManager after placing self on Tree: ", selfTreePath)
         selfTreeBranch = potentialManager.getBranchNode(traversalList = selfTreePath)
         #print("selfTreeBranch in setManager: ", selfTreeBranch)
         #Goes through all attributes on the object, and loads them or their duplicates
@@ -357,7 +357,7 @@ class treeObject:
                         continue
                     elif(not type(someValue).__name__ in atrTypeList):
                         atrTypeList.append(type(someValue).__name__)
-                    print("Analyzing someValue in list in managerSet.")
+                    #print("Analyzing someValue in list in managerSet.")
                     #Ensure polyTyping object exists for the value
                     valuePolyTyping = potentialManager.getObjectTyping(classInstance=someValue)
                     if(valuePolyTyping != None):
@@ -371,7 +371,7 @@ class treeObject:
                             #continue
                             #If the value's tuple is not anywhere in the current branch
                             if(not valueInstanceTuple in selfTreeBranch.keys()):
-                                print("Adding a branch of an already existing tuple for object: ", someValue)
+                                #print("Adding a branch of an already existing tuple for object: ", someValue)
                                 #Check the depth of the original and the depth + 1 of the selfBranch
                                 #If the depth + 1 of current branch is less than original swap original to
                                 #this branch and place duplicate in the old location.
@@ -389,19 +389,19 @@ class treeObject:
                                 print("Value ", someValue, " in list attribute ", someAttrKey, "was already in the correct location on tree before managerSet.")
                         else:
                             #TODO the following code in this else block causes everything to break.
-                            print("potential break reason 1: selfTreePath value: ", selfTreePath)
-                            print("potential break reason 2: valueInstanceTuple value: ", valueInstanceTuple)
-                            print("potential break reason 3: someValue value: ", someValue)
+                            #print("potential break reason 1: selfTreePath value: ", selfTreePath)
+                            #print("potential break reason 2: valueInstanceTuple value: ", valueInstanceTuple)
+                            #print("potential break reason 3: someValue value: ", someValue)
                             #continue
                             if(type(someValue).__name__ != "polyTypedVariable"):
                                 #The tuple does not exist anywhere in the tree, so we simply place a new branch.
                                 potentialManager.addNewBranch(traversalList=selfTreePath, branchTuple=valueInstanceTuple)
                                 if(self != someValue.branch):
-                                    print("Adding self ", self, " to be branch value of child ", someValue)
+                                    #print("Adding self ", self, " to be branch value of child ", someValue)
                                     someValue.branch = self
                                 if(self != someValue.manager):
                                     someValue.manager = self.manager
-                                print("Adding a new tuple to the object tree from a List in managerSet: ", valueInstanceTuple)
+                                #print("Adding a new tuple to the object tree from a List in managerSet: ", valueInstanceTuple)
             #END OF TREE MANAGEMENT FOR TREEOBJECTS IN LISTS OR TUPLES
             #
             #START OF TREE MANAGEMENT FOR TREEOBJECTS DIRECTLY ASSIGNED TO ATTRIBUTES
@@ -427,7 +427,7 @@ class treeObject:
                     valueTreePath = potentialManager.getTuplePathInObjTree(valueInstanceTuple)
                     if(valueTreePath == None):
                         tupleFoundInTree = False
-                        print("Could not retrieve path from manager for the tuple: ", valueInstanceTuple, " which was set as a value on the object ", self)
+                        #print("Could not retrieve path from manager for the tuple: ", valueInstanceTuple, " which was set as a value on the object ", self)
                     #If it is NOT in the branch, check to see if it is in the tree at all.
                     if(not tupleFoundInBranch):
                         if(valueTreePath != None):

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -292,7 +292,12 @@ class treeObject:
                     break
         hasBranch = False
         if(hasattr(self, 'branch')):
+            #Handles the case where the branch is coming off of the manager itself.
+            #TODO Figure out why setting branch as the manager causes infinite loop
+            if(self.branch == potentialManager):
+                hasBranch = True
             for parentObj in (self.branch.__class__).__bases__:
+                print('parent object name for branch, ', self.branch, ' object instance:')
                 if(parentObj.__name__ == 'treeObject'):
                     hasBranch = True
                     break
@@ -327,6 +332,8 @@ class treeObject:
                 continue
             someAttr = getattr(self, someAttrKey)
             atrType = type(someAttr).__name__
+            if(atrType in dataTypesPython):
+                continue
             atrTypeList = []
             #START OF TREE MANAGEMENT FOR TREEOBJECTS IN LISTS OR TUPLES
             #If it is a list, get a list of all referenced object types in the list.
@@ -391,6 +398,7 @@ class treeObject:
                     valueInstanceTuple = potentialManager.getInstanceTuple(someAttr)
                     #Check if the tuple exists somewhere in the current branch
                     tupleFoundInBranch = False
+                    tupleFoundInTree = False
                     for someTuple in selfTreeBranch:
                         #If is in the current branch, ignore it and move to the next iteration.
                         if(not someTuple[0] == valueInstanceTuple[0] and someTuple[1] == valueInstanceTuple[1]):
@@ -398,6 +406,9 @@ class treeObject:
                             tupleFoundInTree = True
                             break
                     valueTreePath = potentialManager.getTuplePathInObjTree(valueInstanceTuple)
+                    if(valueTreePath == None):
+                        tupleFoundInTree = False
+                        print("Could not retrieve path from manager for the tuple: ", valueInstanceTuple, " which was set as a value on the object ", self)
                     #If it is NOT in the branch, check to see if it is in the tree at all.
                     if(not tupleFoundInBranch):
                         if(valueTreePath != None):
@@ -420,7 +431,6 @@ class treeObject:
                                 potentialManager.addNewBranch(traversalList=selfTreePath, branchTuple=duplicateBranchTuple)
                     else:
                         #The tuple does not exist anywhere in the tree, so we simply place it in the branch.
-                        duplicateBranchTuple = tuple([someAttr.__class__.__name__, ids, tuple(valueTreePath)])
                         potentialManager.addNewBranch(traversalList=selfTreePath, branchTuple=valueInstanceTuple)
                         print("Adding a new tuple to the object tree in managerSet: ", valueInstanceTuple)
         #END OF TREE MANAGEMENT FOR TREEOBJECTS IN LISTS OR TUPLES

--- a/objectTreeDecorators.py
+++ b/objectTreeDecorators.py
@@ -131,10 +131,10 @@ class treeObject:
             if(selfPath != None):
                 print("Found appropriate path for treeObject")
                 polyObj = self.manager.getObjectTyping(self.__class__)
-                if value == None or value == []:
+                if value == None:
                     pass
-                elif(type(value) == list):
-                    print("Going through list on treeObject post-init.")
+                elif(type(value).__name__ == "list"):
+                    print("Going through list variable assignment for var ", name ," post-init on treeObject using list ", value)
                     #Adding a list of objects
                     for inst in value:
                         accountedObjectType = False
@@ -151,10 +151,7 @@ class treeObject:
                             managerPolyTyping.addToObjReferenceDict(referencedClassObj=inst.__class__, referenceVarName=name)
                         ids = self.manager.getInstanceIdentifiers(inst)
                         instPath = self.manager.getTuplePathInObjTree(instanceTuple=tuple([inst.__class__.__name__, ids, inst]))
-                        if len(instPath) <= len(selfPath) + 1:
-                            #print("found an instance already in the objectTree at the correct location:", inst)
-                            pass
-                        elif instPath == None:
+                        if instPath == None:
                             #print("found an instance with no existing branch, now creating branch on manager: ", inst)
                             newBranch = tuple([inst.__class__.__name__, ids, inst])
                             self.manager.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
@@ -163,6 +160,9 @@ class treeObject:
                                 inst.branch = self
                             if(self != inst.manager):
                                 inst.manager = self.manager
+                        elif len(instPath) <= len(selfPath) + 1:
+                            #print("found an instance already in the objectTree at the correct location:", inst)
+                            pass
                         else:
                             #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", inst)
                             duplicateBranchTuple = tuple([inst.__class__.__name__, ids, tuple([])]) 
@@ -180,11 +180,7 @@ class treeObject:
                         #if(self.identifiersComplete(value)):
                         ids = self.manager.getInstanceIdentifiers(value)
                         valuePath = self.manager.getTuplePathInObjTree(instanceTuple=tuple([value.__class__.__name__, ids, value]))
-                        if len(valuePath) <= len(selfPath) + 1:
-                            #print("found an instance already in the objectTree at the correct location:", value)
-                            #Do nothing, because the branch is already accounted for.
-                            pass
-                        elif(valuePath == None):
+                        if(valuePath == None):
                             #add the new Branch
                             #print("found an instance with no existing branch, now creating branch on manager: ", value)
                             newBranch = tuple([value.__class__.__name__, ids, value])
@@ -194,6 +190,10 @@ class treeObject:
                                 value.branch = self
                             if(self.manager != value.manager):
                                 value.manager = self.manager
+                        elif len(valuePath) <= len(selfPath) + 1:
+                            #print("found an instance already in the objectTree at the correct location:", value)
+                            #Do nothing, because the branch is already accounted for.
+                            pass
                         else:
                             #add as a duplicate branch
                             #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)
@@ -207,7 +207,7 @@ class treeObject:
                             #TODO make a function that swaps any branching on the original tuple to be on the new location.
                 #Handles the case where a single variable is being set.
                 else:
-                    print("Going through single variable assignment post-init on treeObject.")
+                    print("Going through single variable assignment for var ", name ," post-init on treeObject using value ", value)
                     accountedObjectType = False
                     accountedVariableType = False
                     if(type(value).__class__.__name__ in polyObj.objectReferencesDict):
@@ -233,17 +233,17 @@ class treeObject:
                             ids = self.manager.getInstanceIdentifiers(inst)
                             instPath = self.manager.getTuplePathInObjTree(instanceTuple=tuple([inst.__class__.__name__, ids, inst]))
                             #Case where the existing tuple is at the same level as this object or a lower object, in this case we place a duplicate while leaving the original alone.
-                            if len(instPath) <= len(selfPath) + 1:
-                                #print("found an instance already in the objectTree at the correct location:", inst)
-                                pass
                             #Case where the object has no existing tuple in the tree.
-                            elif instPath == None:
+                            if instPath == None:
                                 #print("found an instance with no existing branch, now creating branch on manager: ", inst)
                                 newBranch = tuple([inst.__class__.__name__, ids, inst])
                                 self.addNewBranch(traversalList=selfPath, branchTuple=newBranch)
                                 #Make sure the new branch has the current manager set on it.
                                 if(self.manager != inst.manager):
                                     inst.manager = self.manager
+                            elif len(instPath) <= len(selfPath) + 1:
+                                #print("found an instance already in the objectTree at the correct location:", inst)
+                                pass
                             else:
                                 #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", inst)
                                 duplicateBranchTuple = tuple([inst.__class__.__name__, ids, tuple([])]) 
@@ -257,11 +257,7 @@ class treeObject:
                         #if(self.identifiersComplete(value)):
                         ids = self.manager.getInstanceIdentifiers(value)
                         valuePath = self.manager.getTuplePathInObjTree(instanceTuple=tuple([value.__class__.__name__, ids, value]))
-                        if len(valuePath) <= len(selfPath) + 1:
-                            #print("found an instance already in the objectTree at the correct location:", value)
-                            #Do nothing, because the branch is already accounted for.
-                            pass
-                        elif(valuePath == None):
+                        if(valuePath == None):
                             #add the new Branch
                             #print("found an instance with no existing branch, now creating branch on manager: ", value)
                             newBranch = tuple([value.__class__.__name__, ids, value])
@@ -269,6 +265,10 @@ class treeObject:
                             #Make sure the new branch has the current manager set on it.
                             if(self.manager != value.manager):
                                 value.manager = self.manager
+                        elif(len(valuePath) <= len(selfPath) + 1):
+                            #print("found an instance already in the objectTree at the correct location:", value)
+                            #Do nothing, because the branch is already accounted for.
+                            pass
                         else:
                             #add as a duplicate branch
                             #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -131,10 +131,12 @@ class managerObject:
                     if(self != value.manager):
                         value.manager = self
         elif(type(value) == list):
-            print("Accounting for setting elements in list on variable \'", name, "\' on the manager object.")
+            print("Accounting for setting elements in list on variable \'", name, "\' on the manager object, with value ", value)
             #Adding a list of objects
             for inst in value:
+                print("accounting for instance in list on manager with value: ", inst)
                 if(inst.__class__.__name__ in dataTypesPython):
+                    print("Skipped inst as a standard type")
                     continue
                 print("accounting for instance in list on manager with value: ", inst)
                 accountedObjectType = False

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -562,6 +562,11 @@ class managerObject:
         elif(branchTuple != None):
             instance = branchTuple[2]
         branchNode = self.getBranchNode(traversalList)
+        branchingInstance = None
+        try:
+            branchingInstance = branchNode[2]
+        except Exception:
+            print("Error: In addNewBranch function, attempted to add new branch using invalid traversal list - ", traversalList)
         if(hasattr(instance, "manager")):
             if(instance.manager == self):
                 pass
@@ -570,6 +575,15 @@ class managerObject:
             else:
                 instance.manager = self
                 #TODO write code to delete branch from other manager and copy to this manager.
+        if(hasattr(instance, "branch") and branchingInstance != None):
+            if(instance.branch == branchNode[2]):
+                pass
+            elif(instance.branch == None):
+                instance.branch = branchNode[2]
+            else:
+                instance.branch = self
+                #TODO this indicates the branch may actually be a duplicate, so we will need to
+                #switch branches instead.
         if(branchNode.get(branchTuple) == None):
             branchNode[branchTuple] = {}
 
@@ -614,7 +628,7 @@ class managerObject:
         source_managedExecutable = self.makeFile(name='managedExecutables', extension='py')
         source_polariServer = self.makeFile(name='polariServer', extension='py')
         #polyTyped Object and variable are both defined in the same source file
-        source_polyTypedObjectANDvariables = self.makeFile(name='polyTyping', extension='py')
+        source_polyTypedObject = self.makeFile(name='polyTyping', extension='py')
         source_polyTypedVars = self.makeFile(name='polyTypedVars', extension='py')
         self_module = inspect.getmodule(self.__class__)
         self_fileName = (self_module.__file__)[self_module.__file__.rfind('\\')+1:self_module.__file__.rfind('.')]
@@ -635,7 +649,7 @@ class managerObject:
             polyTypedObject(sourceFiles=[source_managedDatabase], className='managedDatabase', identifierVariables = ['name','Path'], objectReferencesDict={'managedApp':['DB']}, manager=self),
             polyTypedObject(sourceFiles=[source_dataChannel], className='dataChannel', identifierVariables = ['name','Path'], objectReferencesDict={'polariServer':['serverChannel'],'managedApp':['serverChannel','localAppChannel']}, manager=self),
             polyTypedObject(sourceFiles=[source_managedExecutable], className='managedExecutable', identifierVariables = ['name', 'extension','Path'], objectReferencesDict={}, manager=self),
-            polyTypedObject(sourceFiles=[source_polyTypedObjectANDvariables], className='polyTypedObject', identifierVariables = ['className'], objectReferencesDict={self.__class__.__name__:['objectTyping']}, manager=self),
+            polyTypedObject(sourceFiles=[source_polyTypedObject], className='polyTypedObject', identifierVariables = ['className'], objectReferencesDict={self.__class__.__name__:['objectTyping']}, manager=self),
             polyTypedObject(sourceFiles=[source_polariServer], className='polariServer', identifierVariables = ['name', 'id'], objectReferencesDict={}, manager=self)
         ]
         #Goes through the objectTyping list to make sure that the object

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -134,6 +134,9 @@ class managerObject:
             print("Accounting for setting elements in list on variable \'", name, "\' on the manager object.")
             #Adding a list of objects
             for inst in value:
+                if(inst.__class__.__name__ in dataTypesPython):
+                    continue
+                print("accounting for instance in list on manager with value: ", inst)
                 accountedObjectType = False
                 accountedVariableType = False
                 if(type(inst).__class__.__name__ in polyObj.objectReferencesDict):
@@ -148,7 +151,7 @@ class managerObject:
                     managerPolyTyping.addToObjReferenceDict(referencedClassObj=inst.__class__, referenceVarName=name)
                 ids = self.getInstanceIdentifiers(inst)
                 instPath = self.getTuplePathInObjTree(instanceTuple=tuple([newpolyObj.className, ids, inst]))
-                if instPath == []:
+                if instPath == [selfTuple]:
                     #print("found an instance already in the objectTree at the correct location:", inst)
                     pass
                 elif instPath == None:

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -84,6 +84,7 @@ class managerObject:
             super(managerObject, self).__setattr__(name, value)
             return
         polyObj = self.getObjectTyping(self.__class__)
+        selfTuple = self.getInstanceTuple(instance=self)
         #In polyObj 'polyObj.className' potential references exist for this object.
         #Here, we get each variable that is a reference or a list of references to a
         #particular type of object.
@@ -105,7 +106,7 @@ class managerObject:
                     managerPolyTyping.addToObjReferenceDict(referencedClassObj=value.__class__, referenceVarName=name)
                 ids = self.getInstanceIdentifiers(value)
                 valuePath = self.getTuplePathInObjTree(instanceTuple=tuple([newpolyObj.className, ids, value]))
-                if(valuePath == []):
+                if(valuePath == [selfTuple]):
                     #print("found an instance already in the objectTree at the correct location:", value)
                     #Do nothing, because the branch is already accounted for.
                     pass
@@ -113,7 +114,7 @@ class managerObject:
                     #add the new Branch
                     print("Creating branch on manager for instance on variable ", name, " for instance: ", value)
                     newBranch = tuple([newpolyObj.className, ids, value])
-                    self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                    self.addNewBranch(traversalList=[selfTuple], branchTuple=newBranch)
                     #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                     if(self != value.branch):
                         value.branch = self
@@ -123,7 +124,7 @@ class managerObject:
                     #add as a duplicate branch
                     #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)
                     duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(valuePath)])
-                    self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                    self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[selfTuple,duplicateBranchTuple], newTuple=duplicateBranchTuple)
                     #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                     if(value.branch != self):
                         value.branch = self
@@ -153,7 +154,7 @@ class managerObject:
                 elif instPath == None:
                     print("Creating branch on manager for instance in list on variable ", name, " for instance: ", inst)
                     newBranch = tuple([newpolyObj.className, ids, inst])
-                    self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                    self.addNewBranch(traversalList=[selfTuple], branchTuple=newBranch)
                     #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                     if(self != inst.branch):
                         inst.branch = self
@@ -162,7 +163,7 @@ class managerObject:
                 else:
                     #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", inst)
                     duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(instPath)]) 
-                    self.replaceOriginalTuple(self, originalPath = instPath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                    self.replaceOriginalTuple(self, originalPath = instPath, newPath=[selfTuple,duplicateBranchTuple], newTuple=duplicateBranchTuple)
                     #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                     if(self != inst.branch):
                         inst.branch = self
@@ -179,7 +180,7 @@ class managerObject:
             #if(self.identifiersComplete(value)):
             ids = self.getInstanceIdentifiers(value)
             valuePath = self.getTuplePathInObjTree(instanceTuple=tuple([newpolyObj.className, ids, value]))
-            if(valuePath == []):
+            if(valuePath == [selfTuple]):
                 #print("found an instance already in the objectTree at the correct location:", value)
                 #Do nothing, because the branch is already accounted for.
                 pass
@@ -187,7 +188,7 @@ class managerObject:
                 #add the new Branch
                 print("Creating branch on manager for variable ", name," for instance: ", value)
                 newBranch = tuple([newpolyObj.className, ids, value])
-                self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                self.addNewBranch(traversalList=[selfTuple], branchTuple=newBranch)
                 #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                 if(self != value.branch):
                     value.branch = self
@@ -197,7 +198,7 @@ class managerObject:
                 #add as a duplicate branch
                 #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)
                 duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(valuePath)])
-                self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[selfTuple,duplicateBranchTuple], newTuple=duplicateBranchTuple)
                 #Make sure the new branch has the current manager and the base as it's origin branch set on it.
                 if(self != value.branch):
                     value.branch = self
@@ -345,7 +346,7 @@ class managerObject:
                 print("Called \'makeDefaultObjectTyping\' without passing either a class instance or object for reference, no polyTypedObject could be generated.")
             pass
         except:
-            print('Caught exception for retrieving file, thereby,', classInstance.__class__.__name__ ,' must be a built-in class')
+            print('Caught exception for retrieving file, thereby instance of type', classInstance.__class__.__name__ , ' with a value of ', classInstance,' must be a built-in class')
             isBuiltinClass = True
             pass
         if(isBuiltinClass):
@@ -623,6 +624,8 @@ class managerObject:
 
     #Accesses a branch node and adds a sub-branch to it, if the sub-branch does not already exist.
     def addNewBranch(self, traversalList, branchTuple=None, instance=None):
+        if(len(traversalList) > 2):
+            print("Trying to add new branch using traversalList of depth 3!! -> ", traversalList)
         if(instance != None):
             branchTuple = self.getInstanceTuple(instance)
         elif(branchTuple != None):
@@ -652,6 +655,8 @@ class managerObject:
                 pass
             elif(instance.branch == None):
                 instance.branch = traversalList[len(traversalList) - 1]
+        if(traversalList[len(traversalList) - 1] != branchTuple):
+            newTraversalList = traversalList + [branchTuple]
         if(traversalList == []):
             if(type(instance).__name__ == "treeBranchObject"):
                 print("Attching treeBranchObject at base of tree?")

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -18,6 +18,7 @@ from managedFiles import *
 from managedExecutables import *
 from managedDB import *
 #from managedImages import *
+from polariList import polariList
 from dataChannels import *
 import types, inspect, base64
 
@@ -73,6 +74,12 @@ class managerObject:
         
 
     def __setattr__(self, name, value):
+        if(type(value).__name__ == 'list'):
+            print("converting from list with value ", value, " to a polariList.")
+            #Instead of initializing a polariList, we try to just cast the list to be type polariList.
+            value = polariList(value)
+            value.jumpstart(treeObjInstance=self)
+            print("Set list value to be polariList: ", value)
         if(name == 'manager'):
             #TODO Write functionality to connect with a parent tree when/if manager is assigned.
             super(managerObject, self).__setattr__(name, value)
@@ -130,7 +137,7 @@ class managerObject:
                         value.branch = self
                     if(self != value.manager):
                         value.manager = self
-        elif(type(value) == list):
+        elif(type(value) == list or type(value).__name__ == "polariList"):
             print("Accounting for setting elements in list on variable \'", name, "\' on the manager object, with value ", value)
             #Adding a list of objects
             for inst in value:
@@ -531,7 +538,7 @@ class managerObject:
                         print('trying to get value ', varName, ' from an instance ', curTuple[2], ' in polyObj ', polyObj.className, ' but attribute does not exist on object.')
                     #if(value == None or value == []):
                         #print(varName + ' is an empty variable for object ' + classOfBranch)
-                    if(type(value) == list and not (value == None or value == [])):
+                    if( (type(value) == list or type(value).__name__ == "polariList") and not (value == None or value == [])):
                         #print('Entering variable with list: ' + varName)
                         #Adding a list of objects
                         for inst in value:
@@ -744,6 +751,7 @@ class managerObject:
                 selfIsTyped = True
             if(objTyp.className == 'polyTypedObject'):
                 for typingInst in self.objectTyping:
+                    print("Preparing to analyze instance: ", typingInst)
                     objTyp.analyzeInstance(typingInst)
                 for typingInst in self.objectTyping:
                     for typedVar in typingInst.polyTypedVars:

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -475,14 +475,14 @@ class managerObject:
                 #Case of a dup;icate match, where the path to the original is in the third position.
                 if(type(branchTuple[2]) == tuple):
                     #print('Found tuple match!')
-                    if(branchTuple[2] != [] and branchTuple[2] != None):
-                        print("Returning non-empty path! - ", branchTuple[2])
+                    #if(branchTuple[2] != [] and branchTuple[2] != None):
+                    #    print("Returning non-empty path! - ", branchTuple[2])
                     return branchTuple[2]
                 #Case of an exact match.
                 elif(branchTuple[2] == instanceTuple[2]):
-                    print("Found an exact match in the tree for instance: ", instanceTuple[2])
-                    if(traversalList != [] and traversalList != None):
-                        print("Returning non-empty path! - ", traversalList)
+                    #print("Found an exact match in the tree for instance: ", instanceTuple[2])
+                    #if(traversalList != [] and traversalList != None):
+                    #    print("Returning non-empty path! - ", traversalList)
                     traversalList = traversalList + [branchTuple]
                     return traversalList
                 #print('Found tuple match!')
@@ -491,14 +491,14 @@ class managerObject:
         for branchTuple in branch.keys():
             path = self.getTuplePathInObjTree(traversalList=traversalList+[branchTuple],instanceTuple=instanceTuple)
             if(path != None):
-                if(path != [] and path != None):
-                    print("Returning non-empty path! - ", path)
+                #if(path != [] and path != None):
+                #    print("Returning non-empty path! - ", path)
                 return path
         #if(traversalList == []):
         #    print('Tuple not found in tree!')
         #    print(instanceTuple)
-        if(path != [] and path != None):
-            print("Returning non-empty path! - ", path)
+        #if(path != [] and path != None):
+        #    print("Returning non-empty path! - ", path)
         return path
 
     #Access a single object instance as a node, and checks each typingObject to see what variables
@@ -627,8 +627,8 @@ class managerObject:
 
     #Accesses a branch node and adds a sub-branch to it, if the sub-branch does not already exist.
     def addNewBranch(self, traversalList, branchTuple=None, instance=None):
-        if(len(traversalList) > 2):
-            print("Trying to add new branch using traversalList of depth 3!! -> ", traversalList)
+        #if(len(traversalList) > 2):
+        #    print("Trying to add new branch using traversalList of depth 3!! -> ", traversalList)
         if(instance != None):
             branchTuple = self.getInstanceTuple(instance)
         elif(branchTuple != None):
@@ -661,11 +661,11 @@ class managerObject:
         if(traversalList[len(traversalList) - 1] != branchTuple):
             newTraversalList = traversalList + [branchTuple]
         if(traversalList == []):
-            if(type(instance).__name__ == "treeBranchObject"):
-                print("Attching treeBranchObject at base of tree?")
+            #if(type(instance).__name__ == "treeBranchObject"):
+            #    print("Attching treeBranchObject at base of tree?")
             self.objectTree[branchTuple] = {}
         elif(branchNode.get(branchTuple) == None):
-            print("Adding new node in addNewBranch on sub-path's tuple: ", traversalList[len(traversalList) - 1])
+            #print("Adding new node in addNewBranch on sub-path's tuple: ", traversalList[len(traversalList) - 1])
             branchNode[branchTuple] = {}
 
     #Accesses a branch node and adds an empty duplicate sub-branch, which contain identifiers and

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -390,7 +390,7 @@ class managerObject:
         obj = None
         for parentObj in instance.__class__.__bases__:
             #print("Iterated Parent object in getInstanceIdentifiers: ", parentObj.__name__)
-            if(parentObj.__name__ == "treeObject" or parentObj.__name__ == "managerObject"):
+            if(parentObj.__name__ == "treeObject" or parentObj.__name__ == "managerObject" or parentObj.__name__ == "managedFile"):
                 isValid = True
         #If it is a valid object then we retrieve the object typing, otherwise we let it fail by not defining obj.
         if(isValid):
@@ -763,15 +763,15 @@ class managerObject:
     def makeFile(self, name=None, extension=None, Path = None):
         #print('Entered makefile function')
         if extension in fileExtensions:
-            newFile = managedFile(name=name, extension=extension, Path = Path)
+            newFile = managedFile(name=name, extension=extension, Path = Path, manager=self)
         elif extension in picExtensions:
-            newFile = managedImage(name=name, extension=extension, Path = Path)
+            newFile = managedImage(name=name, extension=extension, Path = Path, manager=self)
         elif extension in dataBaseExtensions:
-            newFile = managedDatabase(name=name, Path = Path)
+            newFile = managedDatabase(name=name, Path = Path, manager=self)
         elif extension in dataCommsExtensions:
-            newFile = dataChannel(name=name, Path = Path)
+            newFile = dataChannel(name=name, Path = Path, manager=self)
         elif extension in executableExtensions:
-            newFile = managedExecutable(name=name, extension=extension, Path = Path)
+            newFile = managedExecutable(name=name, extension=extension, Path = Path, manager=self)
         newFile.openFile()
         (self.managedFiles).append(newFile)
         return newFile

--- a/objectTreeManagerDecorators.py
+++ b/objectTreeManagerDecorators.py
@@ -71,8 +71,6 @@ class managerObject:
         
 
     def __setattr__(self, name, value):
-        #if(name == 'polServer'):
-        #    print('Setting polServer attribute on manager to: ', value)
         if(name == 'manager'):
             #TODO Write functionality to connect with a parent tree when/if manager is assigned.
             super(managerObject, self).__setattr__(name, value)
@@ -114,11 +112,21 @@ class managerObject:
                     print("Creating branch on manager for instance on variable ", name, " for instance: ", value)
                     newBranch = tuple([newpolyObj.className, ids, value])
                     self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                    #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                    if(self != value.branch):
+                        value.branch = self
+                    if(self != value.manager):
+                        value.manager = self
                 else:
                     #add as a duplicate branch
                     #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)
                     duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(valuePath)])
                     self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                    #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                    if(self != value.branch):
+                        value.branch = self
+                    if(self != value.manager):
+                        value.manager = self
         elif(type(value) == list):
             print("Accounting for setting elements in list on variable \'", name, "\' on the manager object.")
             #Adding a list of objects
@@ -144,10 +152,20 @@ class managerObject:
                     print("Creating branch on manager for instance in list on variable ", name, " for instance: ", inst)
                     newBranch = tuple([newpolyObj.className, ids, inst])
                     self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                    #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                    if(self != inst.branch):
+                        inst.branch = self
+                    if(self != inst.manager):
+                        inst.manager = self
                 else:
                     #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", inst)
                     duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(instPath)]) 
                     self.replaceOriginalTuple(self, originalPath = instPath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                    #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                    if(self != inst.branch):
+                        inst.branch = self
+                    if(self != inst.manager):
+                        inst.manager = self
         else:
             #print('Setting attribute to a value: ', value)
             print('Found object: "', value ,'" being assigned to an undeclared reference variable: ', name, 'On object: ', self)
@@ -168,11 +186,21 @@ class managerObject:
                 print("Creating branch on manager for variable ", name," for instance: ", value)
                 newBranch = tuple([newpolyObj.className, ids, value])
                 self.addNewBranch(traversalList=[], branchTuple=newBranch)
+                #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                if(self != value.branch):
+                    value.branch = self
+                if(self != value.manager):
+                    value.manager = self
             else:
                 #add as a duplicate branch
                 #print("Found an instance at a higher level which is now being moved to be a branch on the managed: ", value)
                 duplicateBranchTuple = tuple([newpolyObj.className, ids, tuple(valuePath)])
                 self.replaceOriginalTuple(self, originalPath=valuePath, newPath=[duplicateBranchTuple], newTuple=duplicateBranchTuple)
+                #Make sure the new branch has the current manager and the base as it's origin branch set on it.
+                if(self != value.branch):
+                    value.branch = self
+                if(self != value.manager):
+                    value.manager = self
         #print("Finished setting value of ", name, " to be ", value)
         super(managerObject, self).__setattr__(name, value)
 
@@ -196,9 +224,15 @@ class managerObject:
         if className != None:
             print("Attempted to retrieve a polyTypedObject that does not exist \"", className, "\" using it\'s name as a string.  Cannot generate a default polyTypedObject using a passed string, pass either an object instance or the class object \'__class__\' to generate a default polyTypedObject.")
         elif classInstance != None:
-            obj = self.makeDefaultObjectTyping(classInstance=classInstance)
+            if(classInstance.__class__.__name__ == 'polyTypedObject' or classInstance.__class__.__name__ == 'polyTypedVar'):
+                print('Trying to create typing for polyTyping when it should already exist.')
+            else:
+                obj = self.makeDefaultObjectTyping(classInstance=classInstance)
         elif classObj != None:
-            obj = self.makeDefaultObjectTyping(classObj=classObj)
+            if(classObj.__name__ == 'polyTypedObject' or classObj.__name__ == 'polyTypedVar'):
+                print('Trying to create typing for polyTyping when it should already exist.')
+            else:
+                obj = self.makeDefaultObjectTyping(classObj=classObj)
         return obj
 
     #Retrieves the source file for a given PolyTyped object for a given coding language, with the default set as python language.

--- a/objectTreeManagerDecoratorsTest.py
+++ b/objectTreeManagerDecoratorsTest.py
@@ -246,6 +246,35 @@ class objectTree_TestCase(unittest.TestCase):
         self.assertIsNotNone(listTreeObjOnePath, msg="The first tree object set on a list var on manager after initiation should be in the object tree.")
         self.assertIsNotNone(listTreeObjTwoPath, msg="The second tree object set on a list var on manager after initiation should be in the object tree.")
 
+    def test_postFilledTreeObjectsOnTreeObject(self):
+        #Check to make sure an object typing has been generated for both the manager and the treeObject
+        self.assertIsNotNone(self.mngObj.getObjectTyping(className='testManagerObj'))
+        self.assertIsNotNone(self.mngObj.getObjectTyping(className='testTreeObj'))
+        #Check that the dependency values were populated properly
+        self.assertIsInstance(self.mngObj, testManagerObj, msg="Asserts the manager obect is an instance of the test manager object.")
+        self.assertIsInstance(self.mngObj.someObj_initFilled, testTreeObj, msg="Asserts the value someObj_initFilled on manager obect is an instance of the test tree object.")
+        #Set the values on the single variable treeObject on manager at initiation.
+        self.mngObj.someObj_initFilled.someObj_postFill = testTreeBranchObj(manager=self.mngObj)
+        self.mngObj.someObj_initFilled.objList_postFillList.append(testTreeBranchObj(manager=self.mngObj))
+        self.mngObj.someObj_initFilled.objList_postFillList.append(testTreeBranchObj(manager=self.mngObj))
+        #Check that the values were populated properly
+        self.assertIsInstance(self.mngObj.someObj_initFilled.someObj_postFill, testTreeBranchObj, msg = "Assert the values are set to be testTreeBranchObj type.")
+        self.assertIsInstance(self.mngObj.someObj_initFilled.objList_postFillList[0], testTreeBranchObj, msg = "Assert the values are initially set to be testTreeBranchObj type.")
+        #Check that the values/objects were properly allocated onto the tree.
+        #The manager's path should always be an empty list since it is the base.
+        #The treeObject path, so long as it returns not None meaning a value was found, is good.
+        mngPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj))
+        treeObjPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.someObj_initFilled.someObj_postFill))
+        listTreeObjOnePath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.someObj_initFilled.objList_postFillList[0]))
+        listTreeObjTwoPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.someObj_initFilled.objList_postFillList[1]))
+        #Asserts the manager is at the base.
+        self.assertEqual(len(mngPath), 1, msg="The manager object itself should be at the base of it\'s object tree.")
+        #Asserts the treeObject should be inside the tree.
+        self.assertIsNotNone(treeObjPath, msg="Single tree object set to var on a tree object after initiation should be in the object tree.")
+        #Asserts the treeObject assigned at initiation in a list is in the tree.
+        self.assertIsNotNone(listTreeObjOnePath, msg="The first tree object set on a list var on a tree object after initiation should be in the object tree.")
+        self.assertIsNotNone(listTreeObjTwoPath, msg="The second tree object set on a list var on a tree object after initiation should be in the object tree.")
+
     def test_initFilledTreeObjectsOnTreeObject(self):
         #Check to make sure an object typing has been generated for both the manager and the treeObject
         self.assertIsNotNone(self.mngObj.getObjectTyping(className='testManagerObj'))

--- a/objectTreeManagerDecoratorsTest.py
+++ b/objectTreeManagerDecoratorsTest.py
@@ -106,8 +106,12 @@ class objectTree_TestCase(unittest.TestCase):
         print(self.mngObj.getListOfClassInstances(className='testTreeObj'))
         print('----- List of Test Tree Branch Objects ------')
         print(self.mngObj.getListOfClassInstances(className='testTreeBranchObj'))
+        print('----- List of Objects at Depth 0 in Tree ------')
+        print(self.mngObj.getListOfInstancesAtDepth(target_depth=0))
         print('----- List of Objects at Depth 1 in Tree ------')
         print(self.mngObj.getListOfInstancesAtDepth(target_depth=1))
+        print('----- List of Objects at Depth 2 in Tree ------')
+        print(self.mngObj.getListOfInstancesAtDepth(target_depth=2))
         print('Tearing down at the end of the object tree test case.')
 
     #Tests that all standard variable types can be set and supported on a manager object.

--- a/objectTreeManagerDecoratorsTest.py
+++ b/objectTreeManagerDecoratorsTest.py
@@ -10,7 +10,7 @@ class testManagerObj(managerObject):
         self.var_int = 1
         self.var_float = 0.1
         self.var_complex = complex(1,1)
-        self.var_list = []
+        #self.var_list = []
         self.var_tuple = ()
         self.var_range = range(0,1)
         self.var_dict = {"key":"value"}
@@ -23,9 +23,11 @@ class testManagerObj(managerObject):
         self.var_type = type('str')
         self.var_NoneType = None
         self.var_TextIOWrapper = open("testDocOne.txt","w+")
+        self.var_TextIOWrapper.close()
         #Create one variable for every ignored object type defined, to ensure they can be set properly.
         self.obj_struct_time = time.localtime(time.time())
         self.obj_API = falcon.API()
+        self.obj_polariList = []
         #Create samples of attaching objects to the manager in both single and list format cases, with initial null and empty 
         self.someObj_initFilled = testTreeObj(manager=self)
         self.objList_initFilled = [testTreeObj(manager=self), testTreeObj(manager=self)]
@@ -44,7 +46,7 @@ class testTreeObj(treeObject):
         self.var_int = 1
         self.var_float = 0.1
         self.var_complex = complex(1,1)
-        self.var_list = []
+        #self.var_list = []
         self.var_tuple = ()
         self.var_range = range(0,1)
         self.var_dict = {"key":"value"}
@@ -57,9 +59,11 @@ class testTreeObj(treeObject):
         self.var_type = type('str')
         self.var_NoneType = None
         self.var_TextIOWrapper = open("testDocOne.txt","w+")
+        self.var_TextIOWrapper.close()
         #Create one variable for every ignored object type defined, to ensure they can be set properly.
         self.obj_struct_time = time.localtime(time.time())
         self.obj_API = falcon.API()
+        self.obj_polariList = []
         #Create samples of attaching objects to the manager in both single and list format cases, with initial null and empty 
         self.someObj_initFilled = testTreeBranchObj(manager=self.manager)
         self.objList_initFilled = [testTreeBranchObj(manager=self.manager), testTreeBranchObj(manager=self.manager)]
@@ -121,19 +125,23 @@ class objectTree_TestCase(unittest.TestCase):
         missingIgnoredObjects = []
         wrongIgnoredTypes = []
         for someType in standardTypesPython:
-            if(hasattr(self.mngObj, 'var_' + someType)):
-                someVar = getattr(self.mngObj, 'var_'+someType)
-                if(type(someVar).__name__ == someType):
-                    pass
+            #Dis-regard list because it is replaced by ignored custom type polariList on manager
+            #and tree objects.
+            if(someType != 'list'):
+                if(hasattr(self.mngObj, 'var_' + someType)):
+                    someVar = getattr(self.mngObj, 'var_'+someType)
+                    if(type(someVar).__name__ == someType):
+                        pass
+                    else:
+                        wrongStandardTypes.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
                 else:
-                    wrongStandardTypes.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
-            else:
-                missingStandardTypes.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in manager, but variable did not exist\"')
+                    missingStandardTypes.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in manager, but variable did not exist\"')
         if(len(wrongStandardTypes) != 0):
             print('Wrong Standard Types: ', wrongStandardTypes)
         elif(len(missingStandardTypes) != 0):
             print('Missing Standard Types: ', missingStandardTypes)
         self.assertEqual(len(wrongStandardTypes), 0)
+        #List is going to be missing because it is overwritten by polariList
         self.assertEqual(len(missingStandardTypes), 0)
         
     #Tests that all standard variable types can be set and supported on a tree object.
@@ -143,14 +151,17 @@ class objectTree_TestCase(unittest.TestCase):
         missingIgnoredObjects = []
         wrongIgnoredTypes = []
         for someType in standardTypesPython:
-            if(hasattr(self.mngObj.someObj_initFilled,'var_' + someType)):
-                someVar = getattr(self.mngObj.someObj_initFilled, 'var_'+someType)
-                if(type(someVar).__name__ == someType):
-                    pass
+            #Dis-regard list because it is replaced by ignored custom type polariList on manager
+            #and tree objects.
+            if(someType != 'list'):
+                if(hasattr(self.mngObj.someObj_initFilled,'var_' + someType)):
+                    someVar = getattr(self.mngObj.someObj_initFilled, 'var_'+someType)
+                    if(type(someVar).__name__ == someType):
+                        pass
+                    else:
+                        wrongStandardTypes.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
                 else:
-                    wrongStandardTypes.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
-            else:
-                missingStandardTypes.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
+                    missingStandardTypes.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
         if(len(wrongStandardTypes) != 0):
             print('Wrong Standard Types: ', wrongStandardTypes)
         elif(len(missingStandardTypes) != 0):
@@ -161,15 +172,15 @@ class objectTree_TestCase(unittest.TestCase):
     def test_ignoredObjectsOnManager(self):
         missingIgnoredObjects = []
         wrongIgnoredObjects = []
-        for someType in standardTypesPython:
-            if(hasattr(self.mngObj,'var_' + someType)):
-                someVar = getattr(self.mngObj, 'var_'+someType)
+        for someType in ignoredObjectsPython:
+            if(hasattr(self.mngObj,'obj_' + someType)):
+                someVar = getattr(self.mngObj, 'obj_'+someType)
                 if(type(someVar).__name__ == someType):
                     pass
                 else:
-                    wrongIgnoredObjects.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
+                    wrongIgnoredObjects.append('\"Expected Type: '+ someType + ' in variable obj_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
             else:
-                missingIgnoredObjects.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
+                missingIgnoredObjects.append('\"Expected obj_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
         if(len(wrongIgnoredObjects) != 0):
             print('Wrong Standard Types: ', wrongIgnoredObjects)
         elif(len(missingIgnoredObjects) != 0):
@@ -180,15 +191,15 @@ class objectTree_TestCase(unittest.TestCase):
     def test_ignoredObjectsOnTreeObject(self):
         missingIgnoredObjects = []
         wrongIgnoredObjects = []
-        for someType in standardTypesPython:
-            if(hasattr(self.mngObj.someObj_initFilled,'var_' + someType)):
-                someVar = getattr(self.mngObj.someObj_initFilled, 'var_'+someType)
+        for someType in ignoredObjectsPython:
+            if(hasattr(self.mngObj.someObj_initFilled,'obj_' + someType)):
+                someVar = getattr(self.mngObj.someObj_initFilled, 'obj_'+someType)
                 if(type(someVar).__name__ == someType):
                     pass
                 else:
-                    wrongIgnoredObjects.append('\"Expected Type: '+ someType + ' in variable var_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
+                    wrongIgnoredObjects.append('\"Expected Type: '+ someType + ' in variable obj_' + someType + ', Found Type: ' + type(someVar).__name__ + '\"')
             else:
-                missingIgnoredObjects.append('\"Expected var_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
+                missingIgnoredObjects.append('\"Expected obj_' + someType + ' with a value of type ' + someType +' in the treeObject, but variable did not exist\"')
         if(len(wrongIgnoredObjects) != 0):
             print('Wrong Standard Types: ', wrongIgnoredObjects)
         elif(len(missingIgnoredObjects) != 0):

--- a/objectTreeManagerDecoratorsTest.py
+++ b/objectTreeManagerDecoratorsTest.py
@@ -106,6 +106,8 @@ class objectTree_TestCase(unittest.TestCase):
         print(self.mngObj.getListOfClassInstances(className='testTreeObj'))
         print('----- List of Test Tree Branch Objects ------')
         print(self.mngObj.getListOfClassInstances(className='testTreeBranchObj'))
+        print('----- List of Objects at Depth 1 in Tree ------')
+        print(self.mngObj.getListOfInstancesAtDepth(target_depth=1))
         print('Tearing down at the end of the object tree test case.')
 
     #Tests that all standard variable types can be set and supported on a manager object.
@@ -207,7 +209,7 @@ class objectTree_TestCase(unittest.TestCase):
         listTreeObjOnePath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj))
         listTreeObjTwoPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj))
         #Asserts the manager is at the base.
-        self.assertEqual(len(mngPath), 0, msg="The manager object itself should be at the base of it\'s object tree.")
+        self.assertEqual(len(mngPath), 1, msg="The manager object itself should be at the base of it\'s object tree.")
         #Asserts the treeObject should be inside the tree.
         self.assertIsNotNone(singleTreeObjPath, msg="Single tree object set to var on manager at initiation should be in the object tree.")
         self.assertIsNotNone(listTreeObjOnePath, msg="The first tree object set on a list var on manager at initiation should be in the object tree.")
@@ -234,7 +236,7 @@ class objectTree_TestCase(unittest.TestCase):
         listTreeObjOnePath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.objList_postFillList[0]))
         listTreeObjTwoPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.objList_postFillList[1]))
         #Asserts the manager is at the base.
-        self.assertEqual(len(mngPath), 0, msg="The manager object itself should be at the base of it\'s object tree.")
+        self.assertEqual(len(mngPath), 1, msg="The manager object itself should be at the base of it\'s object tree.")
         #Asserts the treeObject should be inside the tree.
         self.assertIsNotNone(singleTreeObjPath, msg="Single tree object set to var on manager after initiation should be in the object tree.")
         self.assertIsNotNone(listTreeObjOnePath, msg="The first tree object set on a list var on manager after initiation should be in the object tree.")
@@ -256,7 +258,7 @@ class objectTree_TestCase(unittest.TestCase):
         listTreeObjOnePath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.someObj_initFilled.objList_initFilled[0]))
         listTreeObjTwoPath = self.mngObj.getTuplePathInObjTree(self.mngObj.getInstanceTuple(self.mngObj.someObj_initFilled.objList_initFilled[1]))
         #Asserts the manager is at the base.
-        self.assertEqual(len(mngPath), 0, msg="The manager object itself should be at the base of it\'s object tree.")
+        self.assertEqual(len(mngPath), 1, msg="The manager object itself should be at the base of it\'s object tree.")
         #Asserts the treeObject should be inside the tree.
         self.assertIsNotNone(treeObjPath, msg="Single tree object set to var on a tree object at it\'s initiation should be in the object tree.")
         #Asserts the treeObject assigned at initiation in a list is in the tree.

--- a/polariList.py
+++ b/polariList.py
@@ -1,0 +1,13 @@
+class polariList(list):
+    #Aside from directly setting the list, other methods of adding and taking away are not traced
+    def append(self, value):
+        return list.append(object=value)
+
+    def pop(self, value):
+        return list.append(object=value)
+
+    def __setitem__(self, key, value):
+        return super().__setitem__(key, value)
+
+    def __delitem__(self, key):
+        return super().__delitem__(key)

--- a/polariList.py
+++ b/polariList.py
@@ -1,10 +1,24 @@
 class polariList(list):
+    def jumpstart(self, treeObjInstance):
+        #print("eval of polariList before treeObjInstance is set: ", self)
+        self.treeObjInstance = treeObjInstance
+        #print("eval of polariList after treeObjInstance is set: ", self)
+
     #Aside from directly setting the list, other methods of adding and taking away are not traced
     def append(self, value):
-        return list.append(object=value)
+        #if(type(value) == polariList):
+        #    value = list(value)
+        #if(type(value) != list and type(value) != polariList):
+        #    value = [value]
+        print("appending on polariList object")
+        print("instance that this polariList instance is attached to is: ", self.treeObjInstance)
+        super().append(value)
+
+    def __len__(self):
+        return super().__len__()
 
     def pop(self, value):
-        return list.append(object=value)
+        super().pop(value)
 
     def __setitem__(self, key, value):
         return super().__setitem__(key, value)

--- a/polyTypedVars.py
+++ b/polyTypedVars.py
@@ -9,6 +9,7 @@ class polyTypedVariable(treeObject):
         #The name of the variable in the class
         self.polyTypedObj = polyTypedObj
         self.name = attributeName
+        self.manager = polyTypedObj.manager
         #if(polyTypedObj == 'testObj'):
         #    print('Making testObj on polariServer for variable: ', attributeName)
         #Breaks down a data type into the programming language name of the data type,

--- a/polyTyping.py
+++ b/polyTyping.py
@@ -45,7 +45,7 @@ class polyTypedObject(treeObject):
         #Variables that may be used as unique identifiers.
         if(identifierVariables == [] or identifierVariables == ['id']):
             self.identifiers = ['id']
-        elif(type(identifierVariables).__name__ == 'list'):
+        elif(type(identifierVariables).__name__ == 'list' or type(identifierVariables).__name__ == 'polariList'):
             self.identifiers = identifierVariables
         else:
             #This should probably throw an error, but I'll just be nice and autocorrect it to the default if someone messes things up for now.
@@ -153,7 +153,9 @@ class polyTypedObject(treeObject):
 
 
     def analyzeVariableValue(self, pythonClassInstance, varName, varVal):
-        #print('Analyzing variable ' + varName + ' in class ' + self.className)
+        print('Analyzing variable ' + varName + ' in class ' + self.className)
+        if(self.polyTypedVars == None):
+            self.polyTypedVars = []
         numAccVars = len(self.polyTypedVars)
         foundVar = False
         for polyVar in self.polyTypedVars:

--- a/polyTyping.py
+++ b/polyTyping.py
@@ -132,7 +132,10 @@ class polyTypedObject(treeObject):
     #Creates typing for the instance by analyzing it's variables and creating
     #default polyTypedVariables for it.
     def analyzeInstance(self, pythonClassInstance):
-        classInfoDict = pythonClassInstance.__dict__
+        try:
+            classInfoDict = pythonClassInstance.__dict__
+        except Exception:
+            print('Invalid value of type ', type(pythonClassInstance).__name__,' in function analyzeInstance for parameter pythonClassInstance: ', pythonClassInstance)
         for someVariableKey in classInfoDict:
             if(not callable(classInfoDict[someVariableKey])):
                 #print('accVar: ' + someVariableKey)

--- a/polyTyping.py
+++ b/polyTyping.py
@@ -61,6 +61,11 @@ class polyTypedObject(treeObject):
     #and ensure that our current variable's name is within the list which is the value owned by that key.
     def addToObjReferenceDict(self, referencedClassObj, referenceVarName):
         foundTyping = False
+        if(referencedClassObj.__name__ == "polyTypedObject"):
+            print("Changing reference dict on polyTyping after init")
+            if(referenceVarName == "polyTypedObj"):
+                print("For some reason trying to put polyTypedObj onto ref dict... not okay.")
+                return
         if(hasattr(self, 'manager')):
             #print('Adding obj ', classObj, ' to object ref dict of ', self.className, ' for variable named: ', varName)
             for objType in self.manager.objectTyping:
@@ -137,6 +142,8 @@ class polyTypedObject(treeObject):
         except Exception:
             print('Invalid value of type ', type(pythonClassInstance).__name__,' in function analyzeInstance for parameter pythonClassInstance: ', pythonClassInstance)
         for someVariableKey in classInfoDict:
+            if(someVariableKey == "polyTypedObj"):
+                print("TRYING TO SET TYPE polyTypedObj in dict.. why?!?")
             if(not callable(classInfoDict[someVariableKey])):
                 #print('accVar: ' + someVariableKey)
                 var = getattr(pythonClassInstance, someVariableKey)


### PR DESCRIPTION
By creating the polariList type it enables users of the framework to use lists normally on treeObject and managerObject types and have the tree functionality generate nodes in the tree, track typing, generate apis, and database tables for any treeObject or (in the future) ties to other managerObjects to help ensure integrity of a given network of Logic Trees.